### PR TITLE
Add .gitignore for common artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,25 @@
+# Node modules
+node_modules/
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Editor directories and files
+*~
+.*.sw?
+.#*
+*#
+
+# OS generated files
+.DS_Store
+Thumbs.db
+
+# Build output
+/dist/
+/build/
+/coverage/
+
+# Misc
+.env


### PR DESCRIPTION
## Summary
- ignore node modules, log files, editor temp files and OS-specific files
- ignore common build output directories

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: cannot find module jest)*

------
https://chatgpt.com/codex/tasks/task_e_684a0bc05a2c83209bea5c72482269ac