### PR TITLE
Add guard clause to calcStats

### DIFF
--- a/js/stats.js
+++ b/js/stats.js
@@ -1,4 +1,7 @@
 export function calcStats(priceArr, annFactor = 252) {
+  if (!Array.isArray(priceArr) || priceArr.length < 2) {
+    return { mu: 0, sigma: 0 };
+  }
   const rets = priceArr.slice(1).map((p,i)=>Math.log(p/priceArr[i]));
   const mu   = rets.reduce((s,v)=>s+v,0)/rets.length * annFactor;
 

--- a/test/stats.test.js
+++ b/test/stats.test.js
@@ -9,3 +9,9 @@ test("Risk/return differ between 5-y and 10-y windows", ()=>{
   expect(Math.abs(s5.mu  - s10.mu)).toBeGreaterThan(0.005);
   expect(Math.abs(s5.sigma- s10.sigma)).toBeGreaterThan(0.005);
 });
+
+test("calcStats returns zeros for invalid input", ()=>{
+  expect(calcStats([])).toEqual({ mu: 0, sigma: 0 });
+  expect(calcStats([100])).toEqual({ mu: 0, sigma: 0 });
+  expect(calcStats(null)).toEqual({ mu: 0, sigma: 0 });
+});


### PR DESCRIPTION
## Summary
- handle bad price array arguments in `calcStats`
- test handling of invalid input

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_684a0f6acbec8320b8aa10bbe916fe0e