### PR TITLE
Add dark mode support

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -13,7 +13,24 @@
             --card-bg: #FFFFFF; /* Fondo de tarjetas */
             --shadow-sm: 0 2px 4px rgba(0,0,0,0.05);
             --shadow-md: 0 4px 8px rgba(0,0,0,0.07);
-            --border-radius: 6px; /* Radio de borde uniforme */
+        --border-radius: 6px; /* Radio de borde uniforme */
+        }
+
+        [data-theme='dark'] {
+            --primary-color: #3b82f6; /* Azul oscuro */
+            --secondary-color: #a855f7; /* Morado */
+            --success-color: #22c55e; /* Verde */
+            --danger-color: #ef4444; /* Rojo */
+            --warning-color: #eab308; /* Naranja */
+            --info-color: #0ea5e9; /* Cian */
+            --light-bg: #121212; /* Fondo oscuro */
+            --dark-text: #f8f9fa; /* Texto claro principal */
+            --medium-text: #ced4da; /* Texto medio claro */
+            --light-text: #adb5bd; /* Texto tenue */
+            --border-color: #495057; /* Bordes oscuros */
+            --card-bg: #1e1e1e; /* Fondo tarjetas */
+            --shadow-sm: 0 2px 4px rgba(0,0,0,0.4);
+            --shadow-md: 0 4px 8px rgba(0,0,0,0.6);
         }
 
         body {

--- a/index.html
+++ b/index.html
@@ -15,8 +15,9 @@
 </head>
 
 <body>
-  <header class="bg-light py-3 mb-3">
-    <h1 class="text-center">Optimizador de Portafolio Pro</h1>
+  <header class="py-3 mb-3 d-flex align-items-center">
+    <h1 class="flex-grow-1 text-center m-0">Optimizador de Portafolio Pro</h1>
+    <button id="themeToggle" class="btn btn-outline-light ms-3">Modo oscuro</button>
   </header>
 
   <div class="container d-flex">

--- a/js/app.js
+++ b/js/app.js
@@ -10,6 +10,24 @@ const inp          = document.getElementById("asset-search");
 const optimizeBtn  = document.getElementById("optimizeBtn");
 const amountInput  = document.getElementById("investment-amount");
 const riskRange    = document.getElementById("risk-tolerance");
+const themeToggle  = document.getElementById("themeToggle");
+
+function applyTheme(t){
+  document.documentElement.dataset.theme = t;
+  if(themeToggle) themeToggle.textContent = t === "dark" ? "Modo claro" : "Modo oscuro";
+}
+
+function toggleTheme(){
+  const newT = document.documentElement.dataset.theme === "dark" ? "light" : "dark";
+  applyTheme(newT);
+  try{ localStorage.setItem("theme", newT); }catch(e){}
+}
+
+if(themeToggle){
+  const saved = localStorage.getItem("theme");
+  if(saved) applyTheme(saved);
+  themeToggle.addEventListener("click", toggleTheme);
+}
 
 let assets = [];                       // tickers en mayúsculas
 let frontierChart = null;              // referencia a Plotly


### PR DESCRIPTION
## Summary
- define CSS variables for a dark palette under `[data-theme='dark']`
- add "Modo oscuro" button in the header
- toggle a `data-theme` attribute from JavaScript and persist it in `localStorage`

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_684a136d3708832086b80c1bedffa2cb