### PR TITLE
Add error toast for fetch failures

### DIFF
--- a/index.html
+++ b/index.html
@@ -127,6 +127,17 @@
     </div>
   </div>
 
+  <!-- Toast errores (oculto por defecto) -->
+  <div id="errorToast"
+       class="toast text-bg-danger border-0 position-fixed bottom-0 end-0 m-3"
+       role="alert" aria-live="assertive" aria-atomic="true">
+    <div class="d-flex">
+      <div id="errorToastBody" class="toast-body"></div>
+      <button type="button" class="btn-close btn-close-white me-2 m-auto"
+              data-bs-dismiss="toast" aria-label="Cerrar"></button>
+    </div>
+  </div>
+
   <!-- Librerías JS (con defer) -->
   <script defer src="https://cdn.plot.ly/plotly-2.32.0.min.js"></script>
   <script defer src="https://cdn.jsdelivr.net/npm/papaparse@5.3.2/papaparse.min.js"></script>

--- a/js/app.js
+++ b/js/app.js
@@ -107,10 +107,10 @@ async function fetchHistory(tkr, from, to) {
       if (!r.Date || !r.Close) return false;
       return (!from || r.Date >= from) && (!to || r.Date <= to);
     });
-  } catch (err) {
+ } catch (err) {
     console.error("Error descargando", tkr, err);
     const msg = err && err.message ? err.message : err;
-    alert("❌ No se pudo descargar precios para " + tkr + " (" + msg + ")");
+    showErrorToast("❌ No se pudo descargar precios para " + tkr + " (" + msg + ")");
     return [];
   }
 }
@@ -157,7 +157,7 @@ async function updateRiskFree () {
 
   rfInput.value = "";
   const msg = lastError && lastError.message ? lastError.message : lastError;
-  alert(`❌ No pude actualizar la tasa libre de riesgo (${msg}).\nIntenta más tarde.`);
+  showErrorToast(`❌ No pude actualizar la tasa libre de riesgo (${msg}).\nIntenta más tarde.`);
   console.error("updateRiskFree(): ambas fuentes fallaron.", lastError);
 }
 
@@ -349,6 +349,15 @@ function showDateRangeToast(startISO, endISO) {
   const toastEl   = document.getElementById("rangeToast");
   const toastBody = document.getElementById("rangeToastBody");
   toastBody.textContent = `Datos de ${startISO} a ${endISO}`;
+  const toast = bootstrap.Toast.getOrCreateInstance(toastEl, { delay:5000 });
+  toast.show();
+}
+
+/* Toast errores generales */
+function showErrorToast(message) {
+  const toastEl   = document.getElementById("errorToast");
+  const toastBody = document.getElementById("errorToastBody");
+  toastBody.textContent = message;
   const toast = bootstrap.Toast.getOrCreateInstance(toastEl, { delay:5000 });
   toast.show();
 }


### PR DESCRIPTION
## Summary
- add hidden error toast markup
- show error toast from `fetchHistory` and `updateRiskFree`
- include helper `showErrorToast`

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_684a1509209083208ce1db0eb2b2715f